### PR TITLE
Remove %/# from regex

### DIFF
--- a/solution_config/source_config/identity_sds/django_apps/job_tracking_defaults/apps.py
+++ b/solution_config/source_config/identity_sds/django_apps/job_tracking_defaults/apps.py
@@ -34,24 +34,13 @@ def create_defaults(sender, **kwargs):
         IdentityEntry.objects.create(auto_id=3, name="Location 3", type=location_idtype)
         IdentityEntry.objects.create(auto_id=4, name="Complete", type=location_idtype)
 
-    if product_type_created:
-        IdentifierPattern.objects.get_or_create(
-            identifier_type=barcode_identifier_type,
-            id_type= product_type_idtype,
-            defaults={
-                "pattern": "%(?P<name>.*)",
-                "defaults": {"description": ""},
-                "label": "Auto generated default mapping for barcodes to ids for product types",
-            },
-        )
-
     if product_indv_created:
         IdentifierPattern.objects.get_or_create(
             identifier_type=barcode_identifier_type,
             id_type=product_indv_idtype,
             defaults={
-                "pattern": "#(?P<name>.*)",
+                "pattern": "(?P<name>.*)",
                 "defaults": {"description": ""},
-                "label": "Auto generated default mapping for barcodes to ids for individual products",
+                "label": "Unrecognised barcodes become individual products",
             },
         )


### PR DESCRIPTION
Most users of Location Tracking so far don't use the product type feature. They want a simpler system that behaves like old job tracking, and get confused by having to prepend things to their barcodes.

Often when setting up a deployment I have to go into the `Identifier Patterns` settings and remove the `%` one entirely and remove the leading `#` from the other, so that all unrecognised barcodes become individual products of the same name. This PR makes that the default.

I propose that if a user would like the regex from v2.2, they can undo this edit in the web browser. The body of the regex remains so it can be copy/pasted and the %/# added back in. However, the simpler and majority preference should be the default. 

I've also made the label short enough to avoid the error on saving from the web UI when the message is over 50 characters.